### PR TITLE
correctif pour produce_mean > top_abs ne doit pas intégrer l'offset

### DIFF
--- a/src/helpers/road_mesure.py
+++ b/src/helpers/road_mesure.py
@@ -71,12 +71,13 @@ class RoadMeasure():
         """retourne la liste des pr topés."""
         return [key for key in self._tops.keys() if key not in [START, END]]
 
-    def top_abs(self, top_string: str) -> None | float:
+    def top_abs(self, top_string: str, offset=True) -> None | float:
         """retourne l'abscisse du top"""
         top_strings = list(self._tops.keys())
         if top_string not in top_strings:
             return None
-        return self._tops[top_string][0] + self.offset
+        decalage = self.offset if offset else 0
+        return self._tops[top_string][0] + decalage
 
     def tops(self, offset=True) -> dict[str, tuple[float, float]]:
         """retourne les tops."""
@@ -123,7 +124,7 @@ class RoadMeasure():
         LOGGER.debug("nombre de points dans une zone homogène : %s", nb_pts_mean_step)
         # récupération de l'indice de départ
         start_index = 0
-        top_abs = self.top_abs(rec_zh)
+        top_abs = self.top_abs(rec_zh, offset=False)
         if top_abs is not None:
             # les tops peuvent être enregistrés à une précision centrimétrique
             # on arrondit à la précision du relevé (step)


### PR DESCRIPTION
il y a un bug dans produce_mean, et celà devrait corriger les choses, mais il faudrait bien tester pour être sûr.

J'ai fait évoler top_abs sur le même principe que abs avec un paramètre offset = True ou False
En effet dans produce_mean, on travaille sur des abscisses sans offset, il faut donc aussi que l'abscisse du top soit sans offset, sinon ce n'est pas cohérent !!

comportement après correctif : quant on fournit un rec_zh, toutes les zones homogènes commencent bien au niveau de cet événement

# Bessamorel

py .\src\generate_si.py --multi=2 --pr=37 --rec_zh=37

- N88 Bessamorel VL AXE.csv
- RUGO\APO0122030190.SES\APORUG0121030190.RE0

Avant
<img width="832" height="437" alt="{64F9B64D-6480-46A0-A1CA-A1A389F1CABC}" src="https://github.com/user-attachments/assets/16058999-c35f-4368-bc8e-d076b4269a66" />

Après
<img width="855" height="438" alt="{2383D6FF-44E1-4BF1-B998-02F710667A0D}" src="https://github.com/user-attachments/assets/7d3c9d57-a9a0-4cf4-94da-38288896feb3" />

# RD136

py .\src\generate_si.py --multi=2 --pr=0 --rec_zh=0

- RD136 VOIE DROITE PR0 a 4+153.csv
- RD136 VOIE GAUCHE PR4+153 a 0.csv

Avant
<img width="859" height="414" alt="{9BD1FF64-A988-47FE-AF24-85C1F3050A97}" src="https://github.com/user-attachments/assets/1974b8f5-1439-455f-af4f-486135dbf748" />

Après
<img width="863" height="428" alt="{C9898FDA-70EF-4A43-95DD-308FDFCDA8BB}" src="https://github.com/user-attachments/assets/f9429f87-170c-46a2-b43d-66bbacc02c0c" />

