### PR TITLE
Apo - round top abs to measuring step

### DIFF
--- a/src/helpers/apo.py
+++ b/src/helpers/apo.py
@@ -16,12 +16,6 @@ def get_apo_datas(
     folder = os.path.dirname(file_name)
     all_files = os.listdir(folder)
     eve_name = [el for el in all_files if el.endswith(".EV0")][0]
-    with open(f"{folder}/{eve_name}", encoding="utf-8") as evefile:
-        for i,row in enumerate(
-            csv.reader(evefile, delimiter='\t')
-        ):
-            if row[0].lower() == PR:
-                tops[row[2]] = (float(row[1]), 0.0)
     with open(file_name, encoding="utf-8") as datafile:
         data = csv.reader(datafile, delimiter='\t')
         unit_index = None
@@ -33,6 +27,12 @@ def get_apo_datas(
                     step = float(row[1]) - float(row[0])
                 y_datas.append(float(row[unit_index]))
     if step is not None:
+        with open(f"{folder}/{eve_name}", encoding="utf-8") as evefile:
+            for i,row in enumerate(
+                csv.reader(evefile, delimiter='\t')
+            ):
+                if row[0].lower() == PR:
+                    tops[row[2]] = (round(float(row[1])/step)*step, 0.0)
         # pylint: disable=duplicate-code
         return RoadMeasure(
             step=step,


### PR DESCRIPTION
# cas de figure rencontré avec des données de grip au pas de 1 mètre et des données de rugo au pas de 10 mètres

```
py .\src\generate_si.py --multi=2 --pr=37 --rec_zh=37 --bornes 37 36
```

Pour le rugo, après recalage, les abscisses vont être de la forme 664.55 + 10 * k 
Donc 766 ne peut pas être dans la liste 
La solution est de ne pas avoir 101.45 comme abscisse du top mais 100 puisque le pas est de 10 mètres

```
2025-09-09 21:39:56,717 INFO     shared          which_measure :100      opening the file in utf-8
datas\DIRMC\Bessamorel\N88 Bessamorel VL AXE.csv > unité de mesure : CFT
2025-09-09 21:39:56,724 ERROR    shared          which_measure :97       got Unicode error with utf-8, trying another one
2025-09-09 21:39:56,726 INFO     shared          which_measure :100      opening the file in windows-1250
datas\DIRMC\Bessamorel\RUGO\APO0122030190.SES\APORUG0121030190.RE0 > unité de mesure : PMP 
mesure 0
abscisse du pr 37 dans cette mesure : 766.0
tops avant offset {'start': (712.0, 55.08400000000001), '37': (766.0, 56.0755), '36': (1737.0, 54.09250000000001), 'end': (1979.0, 57.067)} 
il y a 972 lignes
2025-09-09 21:39:57,329 DEBUG    road_mesure     produce_mean :155      pas de mesure de l'appareil : 1.0 mètre(s)
2025-09-09 21:39:57,330 DEBUG    road_mesure     produce_mean :157      nombre de points dans une zone homogène : 200
2025-09-09 21:39:57,330 DEBUG    road_mesure     produce_mean :167      indice du top : 766
2025-09-09 21:39:57,331 DEBUG    road_mesure     produce_mean :171      indice de départ zh : 166
mesure 1
tops avant offset {'37': (101.45, 0.0), '36': (1058.78, 0.0)}
on applique un offset 664.55
tops après offset : {'37': (766.0, 0.0), '36': (1723.33, 0.0)}
Traceback (most recent call last):
  File "C:\Users\alexandre.cuer\Documents\GitHub\gdr\src\generate_si.py", line 268, in <module>
    ABSCISSES, data = filtre_bornes(mes, args.bornes)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\alexandre.cuer\Documents\GitHub\gdr\src\generate_si.py", line 168, in filtre_bornes
    mesure.apply_zoom_from_prs(bornes[0], bornes[-1])
  File "C:\Users\alexandre.cuer\Documents\GitHub\gdr\src\helpers\road_mesure.py", line 142, in apply_zoom_from_prs
    self.set_zoom_by_abs(start_abs, end_abs)
  File "C:\Users\alexandre.cuer\Documents\GitHub\gdr\src\helpers\road_mesure.py", line 134, in set_zoom_by_abs
    start_idx = abs_list.index(start_abs) if start_abs is not None else 0
                ^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: 766.0 is not in list
```
@huugoperez : effectivement, ton code original aurait mieux fonctionné mais utiliser index était tellement tentant et puis arrondir l'abcisse du top au pas de mesure relève du bon sens pratique. Que faire de top plus précis que le pas de mesure physique ?

```
def set_zoom_by_abs(self, start_abs: float | None, end_abs: float | None) -> None:
        """Définit le zoom à partir des abscisses (mètres)."""
        abs_list = self.abs(offset=False)
        start_idx, end_idx = 0, len(self.datas)

        if start_abs is not None:
            # On parcourt abs_list jusqu'à trouver le premier point dont l’abscisse >= start_abs
            for i, val in enumerate(abs_list):
                if val >= start_abs:
                    start_idx = i
                    break
        if end_abs is not None:
            # On cherche en partant de la fin le dernier point inférieur ou égal à end_abs
            for i in reversed(range(len(abs_list))):
                if abs_list[i] <= end_abs:
                    end_idx = i + 1
                    break
        self.zoom = (start_idx, end_idx)
```