### PR TITLE
Réglage pb PR Absent

### DIFF
--- a/src/generate_si.py
+++ b/src/generate_si.py
@@ -182,8 +182,12 @@ for j, mes in enumerate(measures):
     if j == 0:
         ax = plt.subplot(INDEX)
         if PR_RECALAGE is not None:
-            ABS_REFERENCE = mes.tops()[PR_RECALAGE][0]
-            print(f"abscisse du pr {PR_RECALAGE} dans cette mesure : {ABS_REFERENCE}")
+            try:
+                ABS_REFERENCE = mes.tops()[PR_RECALAGE][0]
+                print(f"abscisse du pr {PR_RECALAGE} dans cette mesure : {ABS_REFERENCE}")
+            except KeyError:
+                print(f"Attention le PR saisi '{PR_RECALAGE}' est inexistant : pas de recalage")
+                ABS_REFERENCE = None
     else:
         plt.subplot(INDEX, sharex=ax)
     if mes.title is not None:


### PR DESCRIPTION
Avec Try/Except, on règle le pb lorque l'utilisateur affiche un PR absent dans la mesure, le programme ne plante plus. On avertit seulement l'utilisateur, on affiche le graph sans le recalage

Pour résoudre https://github.com/ACF-GTT/gdr/issues/23

A priori, pas de pb similaire avec les autres arguments introduits (bornes et rec_zh)