### PR TITLE
Ajout Totalité descripteurs

### DIFF
--- a/src/configuration.yml
+++ b/src/configuration.yml
@@ -23,7 +23,7 @@ datas:
 aigle_3d : 0
 aigle_xls : "Aigle3D/Table surface AURA_DIRMC_DIRMC.xlsx"
 aigle_sheet : "ie_troncon_surface_25 — DIRMC"
-aigle_gpkg: "Aigle3D/AURA_DIRMC.gpkg"
+aigle_gpkg: "Aigle3D/DIRMC_2025.gpkg"
 aigle_route : N0088
 aigle_dep : 43
 aigle_sens:
@@ -50,6 +50,14 @@ legend: 1
 force_reverse:
 
 descripteurs:
-  - CFT_MOYEN
-  - RAVELING
-
+  DELAMINATION: 0
+  DENSITE_FISSURATION: 1
+  MACROTEXTURE: 0
+  EPO: 0
+  EMO: 0
+  ESTEX: 0
+  RAVELING: 1
+  ORNIERAGE_GRAND_RAYON: 0
+  ORNIERAGE_PETIT_RAYON: 1
+  CFT_MOYEN: 1
+  CLASSE_IQP: 1

--- a/src/helpers/tools_file.py
+++ b/src/helpers/tools_file.py
@@ -79,11 +79,17 @@ class CheckConf():
 
     def get_descripteurs_raw(self) -> list[str] | None:
         """
-        Retourne la liste brute des descripteurs depuis la config.
+        Retourne la liste brute des descripteurs activés.
         """
         raw = self.yaml.get("descripteurs")
         if raw is None:
             return None
-        if not isinstance(raw, list):
-            raise ValueError("La clé 'descripteurs' doit être une liste")
-        return [str(d) for d in raw]
+
+        if not isinstance(raw, dict):
+            raise ValueError("La clé 'descripteurs' doit être un dictionnaire")
+
+        return [
+            str(name)
+            for name, enabled in raw.items()
+            if bool(enabled)
+        ]


### PR DESCRIPTION
Ajout de l'ensemble des descripteurs en configuration : fonctionnement en booléen avec 0 ou 1 pour l'activation)